### PR TITLE
Fix broken DE translations

### DIFF
--- a/locales/de.js
+++ b/locales/de.js
@@ -631,7 +631,7 @@ square_error_payment_method:
 "Die Überprüfung der Karte ist fehlgeschlagen. Bitte überprüfen Sie die Angaben.",
 save:
 "speichern",
-processing,
+processing:
 "in Bearbeitung…",
 preparing_payment:
 "wird vorbereitet…",


### PR DESCRIPTION
A [recent commit](https://github.com/snipcart/snipcart-localization-v2/commit/5c5e6cf64b59264531588ba777f5e21f1648d054) introduced invalid syntax to the German localizations, breaking German Snipcart translations altogether. This fixes the issue.